### PR TITLE
Fix off by one recording count (length)

### DIFF
--- a/recording.php
+++ b/recording.php
@@ -23,7 +23,7 @@ function scan_dir($dir) {
 $files = (scan_dir($svx_folder));
 $array_json =array();
 $i=0;
-$array_json['length'] = sizeof($files)+1;
+$array_json['length'] = sizeof($files);
 foreach($files as $key => $val)
 {
  $array_json[$i]['text'] = date ("F d Y H:i:s.", filemtime($val));


### PR DESCRIPTION
The length returned from recording.php is wrong. For an empty directory it returns {"length":1}. If I look at your site it reports a length of 74 even though there only are 73 recordings. So, it seems it reports one too many recordings.

The faulty length cause an error printout in the javascript console. Don't know if it cause any other problems.

This patch will fix the problem.